### PR TITLE
Add docstring support

### DIFF
--- a/clif/protos/ast.proto
+++ b/clif/protos/ast.proto
@@ -27,6 +27,7 @@ message AST {
   optional bool catch_exceptions = 5;  // C++ code may throw.
   repeated Typemap typemaps = 6;   // C++ types and processors for a lang type
   repeated Macro macros = 7;       // Macro definitions to pass through.
+  optional string docstring = 8;   // Module docstring.
 };
 
 message Decl {
@@ -73,7 +74,8 @@ message ClassDecl {
     optional string filename = 3;
   };
   repeated Base cpp_bases = 11;   // Additional info for C++ base classes.
-  // Next available: 14
+  optional string docstring = 14;  // Python class docstring.
+  // Next available: 15
 };
 
 message EnumDecl {
@@ -120,7 +122,8 @@ message FuncDecl {
   optional bool cpp_noexcept = 14;  // Set to true if C++ func is noexcept(true).
   optional bool cpp_opfunction = 17;  // Invoke C++ operator function.
   optional bool cpp_const_method = 19;  // Set to true if C++ func is const.
-  // Next available: 20
+  optional string docstring = 20;  // Python function docstring.
+  // Next available: 21
 };
 
 // ForwardDecl describe a C++ name declaration match (only make sense for
@@ -175,4 +178,3 @@ message Macro {
   optional string name = 1;
   optional bytes definition = 2;
 };
-

--- a/clif/python/astutils.py
+++ b/clif/python/astutils.py
@@ -75,7 +75,7 @@ def Docstring(method):
   yield method.name.native + i + out
   if method.docstring != '':
     yield ''
-    yield '  ' + method.docstring
+    yield method.docstring
   else:
     yield '  Calls C++ function'
     # Gen C++ signature

--- a/clif/python/astutils.py
+++ b/clif/python/astutils.py
@@ -73,7 +73,11 @@ def Docstring(method):
                ('=default' if a.default_value else '') for a in method.params)
   # Gen Python signature
   yield method.name.native + i + out
-  yield '  Calls C++ function'
-  # Gen C++ signature
-  cname = method.name.cpp_name or method.name.native
-  yield '  ' + FuncReturnType(method) + ' ' + cname + FuncParamStr(method)
+  if method.docstring != '':
+    yield ''
+    yield '  ' + method.docstring
+  else:
+    yield '  Calls C++ function'
+    # Gen C++ signature
+    cname = method.name.cpp_name or method.name.native
+    yield '  ' + FuncReturnType(method) + ' ' + cname + FuncParamStr(method)

--- a/clif/python/gen.py
+++ b/clif/python/gen.py
@@ -251,7 +251,7 @@ def VirtualOverriderClass(name, pyname, cname, cfqname, isabstract, idfunc,
   yield '};'
 
 
-def TypeObject(tp_slots, slotgen, pyname, ctor, wname, fqclassname,
+def TypeObject(tp_slots, slotgen, pyname, ctor, docstring, wname, fqclassname,
                abstract, iterator, need_dtor=True, subst_cpp_ptr=''):
   """Generate PyTypeObject methods and table.
 
@@ -307,7 +307,10 @@ def TypeObject(tp_slots, slotgen, pyname, ctor, wname, fqclassname,
   tp_slots['tp_itemsize'] = tp_slots['tp_version_tag'] = '0'
   tp_slots['tp_dictoffset'] = tp_slots['tp_weaklistoffset'] = '0'
   tp_slots['tp_flags'] = ' | '.join(tp_slots['tp_flags'])
-  tp_slots['tp_doc'] = '"CLIF wrapper for %s"' % fqclassname
+  if docstring != '':
+    tp_slots['tp_doc'] = '"%s"' % docstring
+  else:
+    tp_slots['tp_doc'] = '"CLIF wrapper for %s"' % fqclassname
   wtype = '%s_Type' % wname
   yield ''
   yield 'PyTypeObject %s = {' % wtype

--- a/clif/python/pyext.py
+++ b/clif/python/pyext.py
@@ -228,7 +228,7 @@ class Module(object):
       meth += ' | METH_CLASS'
     # Keep '#' in method name to distinguish map/seq slots.
     self.methods.append((f.name.native.rstrip('@'), wrapper_name, meth,
-                         '\\n'.join(astutils.Docstring(f)).replace('"', '\\"')))
+                         '\\n'.join(astutils.Docstring(f))))
 
   def _FunctionCallExpr(self, f, cname, pyname):
     """Find function call/postcall C++ expression."""

--- a/clif/python/pytd2proto.py
+++ b/clif/python/pytd2proto.py
@@ -937,4 +937,4 @@ def _fix_special_names(ast_name):
   return ast_name
 
 def _process_docstring(docstring):
-  return inspect.cleandoc(docstring).replace('\n', '\\n')
+  return inspect.cleandoc(docstring).replace('\n', '\\n').replace('"', '\\"')

--- a/clif/python/pytd2proto.py
+++ b/clif/python/pytd2proto.py
@@ -612,7 +612,8 @@ class Postprocessor(object):
           raise ValueError('Inplace ops can\'t have "return Postprocess(...)"')
         f.postproc = '->self'  # '->' indicate special postprocessing.
     if return_self and f.postproc != '->self':
-      raise ValueError('Only inplace ops can return "self".')    if ast.func_block:
+      raise ValueError('Only inplace ops can return "self".')
+    if ast.func_block:
       func_block = ast.func_block[0][0]
       if func_block.docstring:
           f.docstring = _process_docstring(func_block.docstring[0])

--- a/clif/python/pytd2proto.py
+++ b/clif/python/pytd2proto.py
@@ -301,7 +301,7 @@ class Postprocessor(object):
 
   def _docstring(self, unused_ln, p, pb):
       assert len(p) == 1, str(p)
-      pb.docstring = inspect.cleandoc(p[0]).replace('\n', '\\n')
+      pb.docstring = _process_docstring(p[0])
 
   # decl
 
@@ -329,7 +329,7 @@ class Postprocessor(object):
     pyname = p.name.native
     self.check_known_name(pyname)
     if ast.docstring:
-      p.docstring = inspect.cleandoc(ast.docstring[0]).replace('\n', '\\n')
+      p.docstring = _process_docstring(ast.docstring[0])
     decorators = ast.decorators.asList()
     if not is_iterator:
       self._typetable[pyname] = [p.name.cpp_name]
@@ -530,8 +530,7 @@ class Postprocessor(object):
                     lambda x, f=f: _set_keep_gil(f, x))
       f.ignore_return_value = True
     if ast.docstring:
-      p.cpp_get.docstring = inspect.cleandoc(ast.docstring[0]).replace('\n',
-                                                                       '\\n')
+      p.cpp_get.docstring = _process_docstring(ast.docstring[0])
     return p.name.native
 
   def _const(self, ln, ast, pb, ns=None):
@@ -613,12 +612,10 @@ class Postprocessor(object):
           raise ValueError('Inplace ops can\'t have "return Postprocess(...)"')
         f.postproc = '->self'  # '->' indicate special postprocessing.
     if return_self and f.postproc != '->self':
-      raise ValueError('Only inplace ops can return "self".')
-    if ast.func_block:
+      raise ValueError('Only inplace ops can return "self".')    if ast.func_block:
       func_block = ast.func_block[0][0]
       if func_block.docstring:
-          f.docstring = inspect.cleandoc(func_block.docstring[0]).replace('\n',
-                                                                          '\\n')
+          f.docstring = _process_docstring(func_block.docstring[0])
       if func_block.postproc:
         name = func_block.postproc[0]
         try:
@@ -938,3 +935,6 @@ def _fix_special_names(ast_name):
     if op:
       return [op, pyname]
   return ast_name
+
+def _process_docstring(docstring):
+  return inspect.cleandoc(docstring).replace('\n', '\\n')

--- a/clif/python/pytd_parser.py
+++ b/clif/python/pytd_parser.py
@@ -62,7 +62,7 @@ ANGLED = lambda el: S('<') - el - S('>')
 
 QSTRING = pp.QuotedString('"')
 ASTRING = pp.QuotedString('`')
-DSTRING = pp.QuotedString('"""', multiline=True)
+DSTRING = pp.QuotedString('"""', multiline=True, convertWhitespaceEscapes=False)
 NAME = pp.Word(pp.alphas+'_', pp.alphanums+'_').setName('name')
 dotted_name = pp.delimitedList(NAME, '.', combine=True)
 


### PR DESCRIPTION
I know you don't yet accept pull requests but I am opening this just in case.
Feel free to ignore it or leave it for later. I already signed the CLA. Cheers..

This commit adds support for optional module, class, function/method
and property docstrings in CLIF files. Docstrings are multiline strings
enclosed by """triple double quotes""". They largely follow the usual
Python docstring conventions (PEP 257). If a docstring is provided,
then it overrides the default docstring generated by CLIF. The only
exception to this rule is the handling of function/method docstrings,
which are automatically prepended with the function/method signatures.
All docstrings provided in CLIF files are cleaned up with the cleandoc
function from inspect module to normalize indentation and whitespace.
Example:

```python
"""Module Docs."""

from clif.python.postproc import ValueErrorOnFalse

from "header.h":
  namespace `ns`:
    class C:
      """Class docs"""

      @getter
      def `b` as get_b(self) -> bool:
        """b getter docs."""
      @setter
      def `b` as set_b(self, val: bool):
        """b setter docs."""

      i: int
      """i docs."""

      s: str = property(`get_s`, `set_s`)
      """s docs."""

      def f(self, opts: int) -> (ret: bool, value: str):
        """Function docs.

        First line.
          Indented line.
        Last line.
        """
        return ValueErrorOnFalse(...)
```