### PR TITLE
Allow regular in-place methods to optionally return self

### DIFF
--- a/clif/python/pytd2proto.py
+++ b/clif/python/pytd2proto.py
@@ -541,6 +541,12 @@ class Postprocessor(object):
     f = pb.func
     _set_name(f.name, _fix_special_names(ast.name), ns, allow_fqcppname=True)
     if ast.returns and ast.returns.asList() == [['', [['self']]]]:
+      if ast.self != 'self':
+        raise NameError('Method %s returning "self" must have "self" as the '
+                        'first argument.' % f.name.native)
+      if ast.postproc:
+        raise ValueError('Method %s returning "self" can\'t have '
+                         '"return Postprocess(...)"' % f.name.native)
       del ast['returns']
       return_self = True
     else:
@@ -592,16 +598,10 @@ class Postprocessor(object):
                         % f.name.cpp_name)
     elif f.name.native in _IGNORE_RETURN_VALUE:
       f.ignore_return_value = True
-      if f.name.native in _INPLACE_OPS:
-        if ast.self != 'self':
-          raise NameError('Inplace ops must have "self" as the first argument.')
-        if not return_self:
-          raise NameError('Inplace ops must return "self".')
-        if ast.postproc:
-          raise ValueError('Inplace ops can\'t have "return Postprocess(...)"')
-        f.postproc = '->self'  # '->' indicate special postprocessing.
-    if return_self and f.postproc != '->self':
-      raise ValueError('Only inplace ops can return "self".')
+      if f.name.native in _INPLACE_OPS and not return_self:
+        raise NameError('Inplace ops must return "self".')
+    if return_self:
+      f.postproc = '->self'  # '->' indicate special postprocessing.
     if ast.postproc:
       name = ast.postproc[0][0][0]
       try:
@@ -721,7 +721,7 @@ def _set_bases(pb, ast_bases, names, typetable):
       try:
         n = names[n]  # Resolve to FQName.
       except KeyError:
-        # 
+        #
         if n not in typetable:
           raise NameError('Base class %s not defined' % n)
     base = pb.add()
@@ -891,7 +891,7 @@ _SPECIAL = {
     '__next__': 'operator*',  # For the "class __iter__: def __next__" case.
     '__int__': 'operator int',
     '__float__': 'operator double',
-    # 
+    #
     # so will have only one in the future.
     '__nonzero__': 'operator bool',  # PY2
     '__bool__': 'operator bool',  # PY3


### PR DESCRIPTION
This commit removes the limitation that only special in-place ops can
return "self". After this change, any method without a return value
can optionally return "self". This is useful for enabling method
chaining without writing additional Python wrappers.