### PR TITLE
Set tp_call slot to __call__ wrapper if it is defined.

### DIFF
--- a/clif/python/pyext.py
+++ b/clif/python/pyext.py
@@ -452,6 +452,9 @@ class Module(object):
           for s in gen.MethodDef(self.methods):
             yield s
           tp_slots['tp_methods'] = gen.MethodDef.name
+          for name, wrapper_name, _, _ in self.methods:
+              if name == '__call__':
+                  tp_slots['tp_call'] = '(ternaryfunc)%s' % wrapper_name
     qualname = '.'.join(f.pyname for f in self.nested)
     tp_slots['tp_name'] = '"%s.%s"' % (self.path, qualname)
     if c.async_dtor and c.cpp_has_trivial_dtor:


### PR DESCRIPTION
This commit sets the `tp_call` slot of a type object to the `__call__` wrapper (if it is defined) which makes the type callable in Python. Currently, `__call__` methods end up as regular methods so instances can not be called even if `__call__` method is defined without further wrapping in Python.